### PR TITLE
Made DoubleJump Work Properly

### DIFF
--- a/projectchronos/Player.cs
+++ b/projectchronos/Player.cs
@@ -177,7 +177,7 @@ public partial class Player : CharacterBody2D {
 			}		
 			else if (hasJumpLeft && !HasDoubJumped) //double jump implementation
 			{
-				velocity += doublejumpForce * UpDirection;
+				velocity = doublejumpForce * UpDirection;
 				hasJumpLeft = false;
 				HasDoubJumped = true;
 				playerSprite.Play("jumping");


### PR DESCRIPTION
Previously double jump was changed such that it adds velocity to the current velocity. It now resets the player velocity so that jumps always occur properly while falling.