### PR TITLE
Player attack cast error

### DIFF
--- a/projectchronos/PlayerAttack.cs
+++ b/projectchronos/PlayerAttack.cs
@@ -23,9 +23,6 @@ public partial class PlayerAttack : Area2D
 	// we use a timer node for handling attack rate
 	private Timer timer;
 
-	// the attack has its own hitbox
-	private CollisionObject2D hitbox;
-
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready() {
 		damage = defaultDamage;

--- a/projectchronos/PlayerAttack.cs
+++ b/projectchronos/PlayerAttack.cs
@@ -35,9 +35,6 @@ public partial class PlayerAttack : Area2D
 		// find the timer and set default rate
 		timer = GetChild<Timer>(1);
 		timer.SetWaitTime((double) AttackPeriod());
-
-		// find out hitbox node
-		hitbox = GetChild<CollisionObject2D>(0);
 	}
 
 	// setting attack frequency is more intuitive for design


### PR DESCRIPTION
Fixed a type mismatch error in unused assignment in PlayerAttack.cs in the _Ready() method.