### PR TITLE
Fixed Level Exit Exception

### DIFF
--- a/projectchronos/SisyphusExitv2.cs
+++ b/projectchronos/SisyphusExitv2.cs
@@ -3,6 +3,7 @@ using System;
 
 public partial class SisyphusExitv2 : Area2D {
 	private Player player;
+	private bool changeScene = false;
 
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready() {
@@ -24,12 +25,14 @@ public partial class SisyphusExitv2 : Area2D {
 
 	// Called every frame. 'delta' is the elapsed time since the previous frame.
 	public override void _Process(double delta) {
+		if (changeScene) {
+			GetTree().ChangeSceneToFile("res://elysium_level.tscn");
+		}
 	}
 
 	public void OnBodyEntered(Node body) {
 		if (body is Player) {
-			// Change scene
-			GetTree().ChangeSceneToFile("res://elysium_level.tscn");
+			changeScene = true;
 		}
 	}
 }

--- a/projectchronos/TartarusExit.cs
+++ b/projectchronos/TartarusExit.cs
@@ -3,6 +3,7 @@ using System;
 
 public partial class TartarusExit : Area2D {
 	private Player player;
+	private bool changeScene = false;
 
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready() {
@@ -24,12 +25,14 @@ public partial class TartarusExit : Area2D {
 
 	// Called every frame. 'delta' is the elapsed time since the previous frame.
 	public override void _Process(double delta) {
+		if (changeScene) {
+			GetTree().ChangeSceneToFile("res://sisyphus_level.tscn");
+		}
 	}
 
 	public void OnBodyEntered(Node body) {
 		if (body is Player) {
-			// Change scene
-			GetTree().ChangeSceneToFile("res://sisyphus_level.tscn");
+			changeScene = true;
 		}
 	}
 }


### PR DESCRIPTION
Entering the level exits caused a collision-related error due to changing scene during collision. Restructured the code to prevent this from happening.