### PR TITLE
Can't Win Without Defeating Sisyphus

### DIFF
--- a/projectchronos/SisyphusExitv2.cs
+++ b/projectchronos/SisyphusExitv2.cs
@@ -4,6 +4,7 @@ using System;
 public partial class SisyphusExitv2 : Area2D {
 	private Player player;
 	private bool changeScene = false;
+	private bool isSisyphusDefeated = false;
 
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready() {
@@ -28,10 +29,15 @@ public partial class SisyphusExitv2 : Area2D {
 		if (changeScene) {
 			((Main) GetTree().CurrentScene).SwitchLevel("res://the_end.tscn");
 		}
+		DefeatedSisyphus();
+	}
+
+	private void DefeatedSisyphus() {
+		isSisyphusDefeated = GetParent().GetChildCount() < 12;
 	}
 
 	public void OnBodyEntered(Node body) {
-		if (body is Player) {
+		if (body is Player && isSisyphusDefeated) {
 			changeScene = true;
 		}
 	}

--- a/projectchronos/enemies/HordeHuman.cs
+++ b/projectchronos/enemies/HordeHuman.cs
@@ -39,7 +39,6 @@ public partial class HordeHuman : BasicEnemy, BasicEnemy.EnemyAI
 		hordeHumanSprite = GetNode<AnimatedSprite2D>("HordeHumanSprite");
 
 		hordeHumanSprite.Play("idle");
-
 	}
 	public override void _PhysicsProcess(double delta) {
 


### PR DESCRIPTION
Added logic to SisyphusExitv2.cs such that the player can only activated the exit and win by first killing sisyphus.